### PR TITLE
Add ignoreSyntax option

### DIFF
--- a/src/textlint-rule-prh.js
+++ b/src/textlint-rule-prh.js
@@ -120,20 +120,21 @@ const getConfigBaseDir = context => {
 
 function reporter(context, options = {}) {
     assertOptions(options);
+    const { Syntax, getSource, report, fixer, RuleError } = context;
     // .textlinrc directory
     const textlintRCDir = getConfigBaseDir(context);
     // create prh config
     const rulePaths = options.rulePaths || [];
     const ruleContents = options.ruleContents || [];
+    const ignoreSyntax = options.ignoreSyntax || [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis];
     // yaml file + yaml contents
     const prhEngineContent = createPrhEngineFromContents(ruleContents);
     const prhEngineFiles = createPrhEngine(rulePaths, textlintRCDir);
     const prhEngine = mergePrh(prhEngineFiles, prhEngineContent);
     const helper = new RuleHelper(context);
-    const { Syntax, getSource, report, fixer, RuleError } = context;
     return {
         [Syntax.Str](node) {
-            if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
+            if (helper.isChildNode(node, ignoreSyntax)) {
                 return;
             }
             const text = getSource(node);

--- a/test/textlintrc-test.js
+++ b/test/textlintrc-test.js
@@ -82,6 +82,43 @@ describe(".textlinrc test", function() {
                 assert(result.messages[1].column === 8);
             });
         });
+        it("by default, should ignore errors in Link, Image, BlockQuote or Emphasis", async function() {
+            var textlint = new TextLintCore();
+            var content = fs.readFileSync(path.join(__dirname, "fixtures", "rule.yaml"), "utf-8");
+            textlint.setupRules(
+                {
+                    prh: rule
+                },
+                {
+                    prh: {
+                        ruleContents: [content]
+                    }
+                }
+            );
+            const result = await textlint.lintMarkdown("# jquery\n![jquery](jquery)\n*jquery*");
+            assert(result.messages.length === 1);
+            assert(result.messages[0].line === 1);
+            assert(result.messages[0].column === 3);
+        });
+        it("should ignore specified AST types", async function() {
+            var textlint = new TextLintCore();
+            var content = fs.readFileSync(path.join(__dirname, "fixtures", "rule.yaml"), "utf-8");
+            textlint.setupRules(
+                {
+                    prh: rule
+                },
+                {
+                    prh: {
+                        ruleContents: [content],
+                        ignoreSyntax: ["Header"]
+                    }
+                }
+            );
+            const result = await textlint.lintMarkdown("# jquery\n*jquery*");
+            assert(result.messages.length === 1);
+            assert(result.messages[0].line === 2);
+            assert(result.messages[0].column === 2);
+        });
     });
 
     context("prh features", function() {


### PR DESCRIPTION
Fixed #33 

## Changes
- Add ignoreSyntax option

## Breaking changes
none

## Question
I can't decide whether to validate syntax type or not.
like,

```js
ignoreSyntax.forEach(syntax => {
  if (typeof Syntax[syntax] === 'undefined') {
    throw new Error(`Invalid syntax type: ${syntax}`)
  }
})
```

How about you?
