### PR TITLE
Feature: add prh to message

### DIFF
--- a/src/textlint-rule-prh.js
+++ b/src/textlint-rule-prh.js
@@ -121,11 +121,13 @@ const forEachChange = (changeSet, str, onChangeOfMatch) => {
         const matchEndIndex = matchStartIndex + diff.matches[0].length;
         // actual => expected
         const actual = str.slice(diff.index + delta, diff.index + delta + diff.matches[0].length);
+        const prh = diff.rule.raw.prh || null;
         onChangeOfMatch({
             matchStartIndex,
             matchEndIndex,
             actual: actual,
-            expected: result
+            expected: result,
+            prh
         });
         str = str.slice(0, diff.index + delta) + result + str.slice(diff.index + delta + diff.matches[0].length);
         delta += result.length - diff.matches[0].length;
@@ -167,13 +169,14 @@ function reporter(context, userOptions = {}) {
             // https://github.com/prh/prh/issues/29
             const dummyFilePath = "";
             const makeChangeSet = prhEngine.makeChangeSet(dummyFilePath, text);
-            forEachChange(makeChangeSet, text, ({ matchStartIndex, matchEndIndex, actual, expected }) => {
+            forEachChange(makeChangeSet, text, ({ matchStartIndex, matchEndIndex, actual, expected, prh }) => {
                 // If result is not changed, should not report
                 if (actual === expected) {
                     return;
                 }
 
-                const messages = actual + " => " + expected;
+                const suffix = prh !== null ? "\n" + prh : "";
+                const messages = actual + " => " + expected + suffix;
                 report(
                     node,
                     new RuleError(messages, {

--- a/test/fixtures/rule.yaml
+++ b/test/fixtures/rule.yaml
@@ -28,6 +28,7 @@ rules:
 # 表現の統一を図る
   - expected: デフォルト
     pattern:  ディフォルト
+    prh: 表記をデフォルトに統一してください
 
 # patternは複数記述可能
   - expected: ハードウェア

--- a/test/prh-rule-tester-test.js
+++ b/test/prh-rule-tester-test.js
@@ -57,7 +57,7 @@ tester.run("prh", rule, {
                 {
                     type: "lint",
                     ruleId: "prh",
-                    message: "行 => おこな",
+                    message: "行 => おこな\n「行う」「行なう」は開く。",
                     index: 0,
                     line: 1,
                     column: 1,
@@ -70,7 +70,7 @@ tester.run("prh", rule, {
                 {
                     type: "lint",
                     ruleId: "prh",
-                    message: "行な => おこな",
+                    message: "行な => おこな\n「行う」「行なう」は開く。",
                     index: 3,
                     line: 1,
                     column: 4,
@@ -83,7 +83,7 @@ tester.run("prh", rule, {
                 {
                     type: "lint",
                     ruleId: "prh",
-                    message: "行 => おこな",
+                    message: "行 => おこな\n「行う」「行なう」は開く。",
                     index: 12,
                     line: 1,
                     column: 13,
@@ -96,7 +96,7 @@ tester.run("prh", rule, {
                 {
                     type: "lint",
                     ruleId: "prh",
-                    message: "行 => おこな",
+                    message: "行 => おこな\n「行う」「行なう」は開く。",
                     index: 16,
                     line: 1,
                     column: 17,
@@ -109,7 +109,7 @@ tester.run("prh", rule, {
                 {
                     type: "lint",
                     ruleId: "prh",
-                    message: "行な => おこな",
+                    message: "行な => おこな\n「行う」「行なう」は開く。",
                     index: 21,
                     line: 1,
                     column: 22,
@@ -178,7 +178,7 @@ tester.run("prh", rule, {
                 {
                     type: "lint",
                     ruleId: "prh",
-                    message: "ディフォルト => デフォルト",
+                    message: "ディフォルト => デフォルト\n表記をデフォルトに統一してください",
                     index: 1,
                     line: 1,
                     column: 2,
@@ -200,7 +200,7 @@ tester.run("prh", rule, {
                 {
                     type: "lint",
                     ruleId: "prh",
-                    message: "ディフォルト => デフォルト",
+                    message: "ディフォルト => デフォルト\n表記をデフォルトに統一してください",
                     index: 2,
                     line: 1,
                     column: 3,


### PR DESCRIPTION
Fixed #5

## Changes
Added `prh` field to message if exists.

### Example (prh field exists):
```yml
version: 1
rules:
  - expected: デフォルト
    pattern:  ディフォルト
    prh: 表記をデフォルトに統一してください
```

```
ディフォルト => デフォルト
表記をデフォルトに統一してください
```

### Example (prh not exists):

```yml
version: 1
rules:
  - expected: jQuery
```

```
ＪＱＵＥＲＹ => jQuery
```
