### PR TITLE
feat(options): support CodeBlock's comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,35 @@ You can use `~` as Home directory abbreviation.
 - `checkBlockQuote`(optional) : Check `BlockQuote` node type (default: `false`)
 - `checkEmphasis`(optional) : Check `Emphasis` node type (default: `false`)
 - `checkHeader`(optional) : Check `Header` node type (default: `true`)
+- `checkCodeComment`(optional) : Check `CodeBlock` node's comment for `lang` (default: `[]`)
+    - Set `lang` array like `["<codeblock-lang>"]` for checking CodeBlock
+    - For example, If you want to check JavaScript CodeBlock, set `{ "checkCodeComment": ["js", "javascript"] }` Options
+    - **Note:** Currently only support JavaScript CodeBlock
+        - It use [@babel/parser](https://babeljs.io/docs/en/babel-parser) 
+
+**Examples**:
 
 ```json
 {
     "rules": {
         "prh": {
             "checkEmphasis": true,
-            "checkHeader": false
+            "checkHeader": false,
+            "rulePaths" :["./prh.yml"]
+        }
+    }
+}
+```
+
+Check CodeBlock's comment in JavaScript Code.
+
+
+```json
+{
+    "rules": {
+        "prh": {
+            "checkCodeComment": ["js", "javascript"],
+            "rulePaths" :["./prh.yml"]
         }
     }
 }
@@ -157,7 +179,7 @@ rules:
 
 #### imports
 
-prh.yml can import other yaml file
+`prh.yml` can import other yaml file
 
 ```yaml
 version: 1

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can use `~` as Home directory abbreviation.
 - `checkHeader`(optional) : Check `Header` node type (default: `true`)
 - `checkCodeComment`(optional) : Check `CodeBlock` node's comment for `lang` (default: `[]`)
     - Set `lang` array like `["<codeblock-lang>"]` for checking CodeBlock
-    - For example, If you want to check JavaScript CodeBlock, set `{ "checkCodeComment": ["js", "javascript"] }` Options
+    - Example: If you want to check JavaScript CodeBlock, set `{ "checkCodeComment": ["js", "javascript"] }` Options
     - **Note:** Currently only support JavaScript CodeBlock
         - It use [@babel/parser](https://babeljs.io/docs/en/babel-parser) 
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prh"
   ],
   "dependencies": {
+    "@babel/parser": "^7.7.5",
     "prh": "^5.4.4",
     "textlint-rule-helper": "^2.1.1",
     "untildify": "^3.0.3"

--- a/test/prh-rule-tester-test.js
+++ b/test/prh-rule-tester-test.js
@@ -25,6 +25,36 @@ tester.run("prh", rule, {
                 rulePaths: [__dirname + "/fixtures/rule.yaml"],
                 checkHeader: false
             }
+        },
+        {
+            text: "```js\n" + "\n" + "\n" + "\n" + "// JavaScript\n" + "var a = 1;\n" + "```",
+            options: {
+                checkCodeComment: ["js"],
+                rulePaths: [__dirname + "/fixtures/rule.yaml"]
+            }
+        },
+        {
+            text: "```js\n" + "// jquery is wrong, but this check is not by default\n" + "```",
+            options: {
+                checkCodeComment: [],
+                rulePaths: [__dirname + "/fixtures/rule.yaml"]
+            }
+        },
+        // empty code block
+        {
+            text: "```js\n" + "```",
+            options: {
+                checkCodeComment: ["js"],
+                rulePaths: [__dirname + "/fixtures/rule.yaml"]
+            }
+        },
+        // The CodeBlock includes invalid syntax, it is just ignored
+        {
+            text: "```js\n" + "+++++++\n" + "// jquery\n" + "```",
+            options: {
+                checkCodeComment: ["js"],
+                rulePaths: [__dirname + "/fixtures/rule.yaml"]
+            }
         }
     ],
     invalid: [
@@ -211,6 +241,71 @@ tester.run("prh", rule, {
                     }
                 }
             ]
+        },
+        // comment
+        {
+            text: "```js\n" + "// $ is jquery\n" + "const $ = jquery;\n" + "```",
+            output: "```js\n" + "// $ is jQuery\n" + "const $ = jquery;\n" + "```",
+            errors: [
+                {
+                    index: 14,
+                    message: "jquery => jQuery"
+                }
+            ],
+            options: {
+                checkCodeComment: ["js"],
+                rulePaths: [__dirname + "/fixtures/rule.yaml"]
+            }
+        },
+        // BlockComment
+        {
+            text: "```js\n" + "/**\n" + " * $ is jquery\n" + " **/" + "const $ = jquery;\n" + "```",
+            output: "```js\n" + "/**\n" + " * $ is jQuery\n" + " **/" + "const $ = jquery;\n" + "```",
+            errors: [
+                {
+                    index: 18,
+                    message: "jquery => jQuery"
+                }
+            ],
+            options: {
+                checkCodeComment: ["js"],
+                rulePaths: [__dirname + "/fixtures/rule.yaml"]
+            }
+        },
+        // BlockComment multiple
+        {
+            text:
+                "```javascript\n" +
+                "/**\n" +
+                " * $ is jquery\n" +
+                " **/" +
+                "/**\n" +
+                " * cookie is Cookie\n" +
+                " **/\n" +
+                "```",
+            output:
+                "```javascript\n" +
+                "/**\n" +
+                " * $ is jQuery\n" +
+                " **/" +
+                "/**\n" +
+                " * Cookie is Cookie\n" +
+                " **/\n" +
+                "```",
+            errors: [
+                {
+                    index: 26,
+                    message: "jquery => jQuery"
+                },
+                {
+                    index: 44,
+                    message: "cookie => Cookie"
+                }
+            ],
+            options: {
+                checkCodeComment: ["javascript"],
+                rulePaths: [__dirname + "/fixtures/rule.yaml"]
+            }
         },
         // example-prh.yml
         {

--- a/test/prh-rule-tester-test.js
+++ b/test/prh-rule-tester-test.js
@@ -5,6 +5,8 @@ var tester = new TextLintTester();
 // rule
 import rule from "../src/textlint-rule-prh";
 // ruleName, rule, { valid, invalid }
+const CODE_START_JS = "```js";
+const CODE_END = "```";
 tester.run("prh", rule, {
     valid: [
         {
@@ -27,14 +29,14 @@ tester.run("prh", rule, {
             }
         },
         {
-            text: "```js\n" + "\n" + "\n" + "\n" + "// JavaScript\n" + "var a = 1;\n" + "```",
+            text: `${CODE_START_JS}\n" + "\n" + "\n" + "// JavaScript\n" + "var a = 1;\n${CODE_END}`,
             options: {
                 checkCodeComment: ["js"],
                 rulePaths: [__dirname + "/fixtures/rule.yaml"]
             }
         },
         {
-            text: "```js\n" + "// jquery is wrong, but this check is not by default\n" + "```",
+            text: `${CODE_START_JS}// jquery is wrong, but this check is not by default\n${CODE_END}`,
             options: {
                 checkCodeComment: [],
                 rulePaths: [__dirname + "/fixtures/rule.yaml"]
@@ -42,7 +44,7 @@ tester.run("prh", rule, {
         },
         // empty code block
         {
-            text: "```js\n" + "```",
+            text: `${CODE_START_JS}${CODE_END}`,
             options: {
                 checkCodeComment: ["js"],
                 rulePaths: [__dirname + "/fixtures/rule.yaml"]
@@ -50,7 +52,10 @@ tester.run("prh", rule, {
         },
         // The CodeBlock includes invalid syntax, it is just ignored
         {
-            text: "```js\n" + "+++++++\n" + "// jquery\n" + "```",
+            text: `${CODE_START_JS}
++++++++
+// jquery
+${CODE_START_JS}`,
             options: {
                 checkCodeComment: ["js"],
                 rulePaths: [__dirname + "/fixtures/rule.yaml"]
@@ -244,8 +249,14 @@ tester.run("prh", rule, {
         },
         // comment
         {
-            text: "```js\n" + "// $ is jquery\n" + "const $ = jquery;\n" + "```",
-            output: "```js\n" + "// $ is jQuery\n" + "const $ = jquery;\n" + "```",
+            text: `${CODE_START_JS}
+// $ is jquery
+const $ = jquery;
+${CODE_END}`,
+            output: `${CODE_START_JS}
+// $ is jQuery
+const $ = jquery;
+${CODE_END}`,
             errors: [
                 {
                     index: 14,
@@ -259,8 +270,18 @@ tester.run("prh", rule, {
         },
         // BlockComment
         {
-            text: "```js\n" + "/**\n" + " * $ is jquery\n" + " **/" + "const $ = jquery;\n" + "```",
-            output: "```js\n" + "/**\n" + " * $ is jQuery\n" + " **/" + "const $ = jquery;\n" + "```",
+            text: `${CODE_START_JS}
+/**
+ * $ is jquery
+ **/
+const $ = jquery;
+${CODE_END}`,
+            output: `${CODE_START_JS}
+/**
+ * $ is jQuery
+ **/
+const $ = jquery;
+${CODE_END}`,
             errors: [
                 {
                     index: 18,

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,6 +265,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.4.tgz#75ab2d7110c2cf2fa949959afb05fa346d2231bb"
   integrity sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==
 
+"@babel/parser@^7.7.5":
+  version "7.7.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.5.tgz#cbf45321619ac12d83363fcf9c94bb67fa646d71"
+  integrity sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==
+
 "@babel/plugin-proposal-async-generator-functions@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz#0351c5ac0a9e927845fffd5b82af476947b7ce6d"
@@ -1379,6 +1384,13 @@ commandpost@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/commandpost/-/commandpost-1.4.0.tgz#89218012089dfc9b67a337ba162f15c88e0f1048"
   integrity sha512-aE2Y4MTFJ870NuB/+2z1cXBhSBBzRydVVjzhFC4gtenEhpnj15yu0qptWGJsO9YGrcPZ3ezX8AWb1VA391MKpQ==
+
+comment-patterns@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/comment-patterns/-/comment-patterns-0.10.1.tgz#4c8a876327f76c09bfb8306272f997f1e317b953"
+  integrity sha512-fKtMiKJAYvwd66zxY5TwNeqmcAr7N3Xjua5Abcrp1cF7QLk2gT8zi2ZWnvNYDwoKheKwvQUJttpHSgQSODjw+g==
+  dependencies:
+    lodash "^4.17.11"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2605,6 +2617,11 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+line-counter@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/line-counter/-/line-counter-1.1.0.tgz#10df2c046ad3546e724fba55fa72cde18a6a01f3"
+  integrity sha1-EN8sBGrTVG5yT7pV+nLN4YpqAfM=
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -2718,7 +2735,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.15:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -2970,6 +2987,16 @@ ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+multilang-extract-comments@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/multilang-extract-comments/-/multilang-extract-comments-0.3.2.tgz#cf19f3c98661de793da6ba0ff5e62b837d0247b8"
+  integrity sha512-H/+eHndsWbGqqQ7FMaYj+1NwFSb0KZFsbWeSGvKz6o1YJMYXFVGLnA6d8f7lSNRQ/wiTLWTmLpOtNyQwaKzgig==
+  dependencies:
+    comment-patterns "^0.10.0"
+    line-counter "^1.0.3"
+    lodash "^4.17.11"
+    quotemeta "0.0.0"
 
 nan@^2.12.1:
   version "2.14.0"
@@ -3522,6 +3549,11 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+quotemeta@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/quotemeta/-/quotemeta-0.0.0.tgz#51d3a06ee0fcd6e3b501dbd28904351ad7a5a38c"
+  integrity sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w=
 
 rc-config-loader@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Features

- Add `checkCodeComment` options

Example


```json
{
    "rules": {
        "prh": {
            "checkCodeComment": ["js", "javascript"],
            "rulePaths" :["./prh.yml"]
        }
    }
}
```

Support `CodeBlock`'s comment `//` and `/*`.

   ```js
   // $ is jquery
   ```

Limitation: It just support JavaScript Code, because I don't found any lang comment parser correctly.

fix #38 