### PR TITLE
docs(README): Change link to the example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ imports:
 
 ## Example
 
-See [textlint-rule/prh-textlint-example: Example of textlint + prh.](https://github.com/textlint-rule/prh-textlint-example "textlint-rule/prh-textlint-example: Example of textlint + prh.").
+See [example-prh.yml](https://github.com/textlint-rule/textlint-rule-prh/blob/master/test/fixtures/example-prh.yml).
 
 
 ## Tests


### PR DESCRIPTION
The repository of configuration examples (https://github.com/textlint-rule/prh-textlint-example) had been deleted.
I've changed the link to [`example-prh.yml`](https://github.com/textlint-rule/textlint-rule-prh/blob/master/test/fixtures/example-prh.yml) in this repository instead.

Thank you for creating a great rule 👏 